### PR TITLE
Fixes to comparison table for mobile

### DIFF
--- a/src/components/comparison/add_player_cell.tsx
+++ b/src/components/comparison/add_player_cell.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { PersonAddAlt1 } from "@mui/icons-material";
+import { Box, Typography, useTheme } from "@mui/material";
+import { Player } from "types";
+
+interface PlayerImageCellProps {
+  player?: Player;
+  onButtonClick: () => void;
+}
+
+export const AddPlayerCell = ({ onButtonClick }: PlayerImageCellProps): JSX.Element => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      borderRadius='50%'
+      className='flex-center'
+      flexDirection='column'
+      fontSize='2.5rem'
+      height='7rem'
+      margin='auto'
+      onClick={onButtonClick}
+      pb={1}
+      sx={{
+        backgroundColor: theme.palette.secondary.main,
+        color: theme.palette.secondary.contrastText,
+        cursor: "pointer",
+        transition: "background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms",
+        "&:hover": {
+          backgroundColor: theme.palette.secondary.dark
+        }
+      }}
+      width='7rem'
+    >
+      <PersonAddAlt1 data-testid='add-icon' fontSize='inherit' sx={{ p: 0 }} />
+      <Typography textTransform='uppercase'>Add Player</Typography>
+    </Box>
+  );
+};

--- a/src/components/comparison/add_players_modal/add_players_table.tsx
+++ b/src/components/comparison/add_players_modal/add_players_table.tsx
@@ -94,7 +94,7 @@ export const AddPlayersTable = ({
       onSelectionModelChange={setSelectionModel}
       pagination
       rows={rows}
-      rowsPerPageOptions={isMobile ? [] : [25, 50, 100]}
+      rowsPerPageOptions={[25]}
       selectionModel={selectionModel}
       sx={{
         "& .MuiDataGrid-columnHeader:focus-within, & .MuiDataGrid-cell:focus-within": {

--- a/src/components/comparison/comparison_table.tsx
+++ b/src/components/comparison/comparison_table.tsx
@@ -4,6 +4,7 @@ import { AppDataContext } from "app_content";
 import { getTeamById } from "helpers";
 import { AppData, Player,PlayerStat, Team } from "types";
 
+import { AddPlayerCell } from "./add_player_cell";
 import { MAX_PLAYER_COUNT, PlayerImageCell } from ".";
 
 interface ComparisonTableProps {
@@ -14,55 +15,58 @@ interface ComparisonTableProps {
   onRemovePlayerClick: (player: Player) => void;
 }
 
-interface TableCellProps {
-  testId?: string;
-}
-
 export const ComparisonTable = ({
   selectedPlayers,
   playerStats,
   onAddPlayerClick,
   onRemovePlayerClick
 }: ComparisonTableProps): JSX.Element => {
-  const { teams, isMobile } = useContext(AppDataContext) as AppData;
+  const { teams } = useContext(AppDataContext) as AppData;
   const theme = useTheme();
+  const isMaxPlayersSelected = selectedPlayers.length >= MAX_PLAYER_COUNT;
 
-  const firstCellStyle = {
-    border: "1px solid rgb(96, 96, 96)",
-    borderLeft: 0,
-    backgroundColor: "rgb(196, 196, 196)",
-    width: isMobile ? "10rem" : "15%",
-    maxWidth: isMobile ? "10rem" : "15%",
-    position: "sticky",
-    left: 0,
-    zIndex: "fab"
+  const tableContainerStyle = {
+    "&::-webkit-scrollbar": {
+      width: 1
+    },
+    "&::-webkit-scrollbar-track": {
+      backgroundColor: "white",
+      border: "0.5px solid black"
+    },
+    "&::-webkit-scrollbar-thumb": {
+      backgroundColor: theme.palette.primary.main,
+      border: "0.5px solid black"
+    }
+  };
+
+  const tableStyle = {
+    height: "100%",
+    width: "100%",
+    "& .MuiTableCell-root": { p: "0.5rem" },
+    tableLayout: "fixed"
   };
 
   const standardCellStyle = {
     border: "1px solid rgb(96, 96, 96)",
-    position: "relative"
+    width: "8rem",
+    height: "2.5rem"
   };
 
-  const FirstCell = ({ testId, children }: React.PropsWithChildren<TableCellProps>): JSX.Element => (
-    <TableCell
-      component='td'
-      data-testid={testId}
-      sx={firstCellStyle}
-    >
-      {children}
-    </TableCell>
-  );
+  const firstCellStyle = {
+    ...standardCellStyle,
+    borderLeft: 0,
+    backgroundColor: "rgb(196, 196, 196)",
+    position: "sticky",
+    left: 0,
+    zIndex: "fab",
+    maxWidth: "8rem"
+  };
 
-  const StandardCell = ({ testId, children }: React.PropsWithChildren<TableCellProps>): JSX.Element => (
-    <TableCell
-      className='first-cell'
-      component='td'
-      data-testid={testId}
-      sx={standardCellStyle}
-    >
-      {children}
-    </TableCell>
-  );
+  const playerImgCellStyle = {
+    ...standardCellStyle,
+    position: "relative",
+    height: "10rem"
+  };
 
   const EmptyCell = (): JSX.Element => (
     <TableCell
@@ -73,30 +77,11 @@ export const ComparisonTable = ({
   );
 
   return (
-    <TableContainer
-      sx={{
-        "&::-webkit-scrollbar": {
-          width: 1
-        },
-        "&::-webkit-scrollbar-track": {
-          backgroundColor: "white",
-          border: "0.5px solid black"
-        },
-        "&::-webkit-scrollbar-thumb": {
-          backgroundColor: theme.palette.primary.main,
-          border: "0.5px solid black"
-        }
-      }}
-    >
+    <TableContainer sx={tableContainerStyle}>
       <Table
         aria-label='player comparison table'
         component='table'
-        sx={{
-          height: "100%",
-          width: "100%",
-          tableLayout: "fixed",
-          "& .MuiTableCell-root": { px: "0.8vw", py: "0.8vh" }
-        }}
+        sx={tableStyle}
       >
         <TableBody component='tbody'>
 
@@ -104,52 +89,82 @@ export const ComparisonTable = ({
           <TableRow component='tr'>
 
             {/* Empty cell */}
-            <FirstCell />
+            <TableCell component='td' sx={firstCellStyle} />
 
             {/* Player image cells */}
             {selectedPlayers.map((player, key) => (
-              <StandardCell key={key}>
+              <TableCell
+                className='first-cell'
+                component='td'
+                data-testid={player.id}
+                key={key}
+                sx={playerImgCellStyle}
+              >
                 <PlayerImageCell onButtonClick={(): void => onRemovePlayerClick(player)} player={player} />
-              </StandardCell>
+              </TableCell>
             ))}
 
-            {/* Add more players cell */}
-            {selectedPlayers.length < MAX_PLAYER_COUNT &&
-              <StandardCell>
-                <PlayerImageCell onButtonClick={onAddPlayerClick} />
-              </StandardCell>}
+            {/* Add players cell */}
+            {!isMaxPlayersSelected &&
+              <TableCell
+                className='first-cell'
+                component='td'
+                data-testid='add-player-cell'
+                sx={playerImgCellStyle}
+              >
+                <AddPlayerCell onButtonClick={onAddPlayerClick} />
+              </TableCell>}
           </TableRow>
 
           {/* Player name row */}
           <TableRow component='tr'>
-            <FirstCell>
+            <TableCell
+              component='td'
+              data-testid='player-name-row-label-cell'
+              sx={firstCellStyle}
+            >
               <Typography className='text-ellipsis'>Name</Typography>
-            </FirstCell>
+            </TableCell>
 
             {/* Player name cells */}
             { selectedPlayers.map((player, key) => (
-              <StandardCell key={key} testId={`player-name-row-${player.id}`}>
+              <TableCell
+                component='td'
+                data-testid={`player-name-row-${player.id}`}
+                key={key}
+                sx={standardCellStyle}
+              >
                 <Typography className='text-ellipsis'>
                   {`${player.first_name} ${player.second_name}`}
                 </Typography>
-              </StandardCell>
+              </TableCell>
             ))}
-            {selectedPlayers.length < MAX_PLAYER_COUNT && <EmptyCell />}
+            {!isMaxPlayersSelected && <EmptyCell />}
           </TableRow>
 
           {/* Team name row */}
           <TableRow component='tr'>
-            <FirstCell>
+            <TableCell
+              component='td'
+              data-testid='team-name-row-label-cell'
+              sx={firstCellStyle}
+            >
               <Typography className='text-ellipsis'>Team</Typography>
-            </FirstCell>
+            </TableCell>
 
             {/* Team name cells */}
             {selectedPlayers.map((player, key) => (
-              <StandardCell key={key} testId={`team-name-row-${player.id}`}>
+              <TableCell
+                className='first-cell'
+                component='td'
+                data-testid={`team-name-row-${player.id}`}
+                key={key}
+                sx={standardCellStyle}
+              >
                 <Typography>{getTeamById(player.team, teams).name}</Typography>
-              </StandardCell>
+              </TableCell>
             ))}
-            {selectedPlayers.length < MAX_PLAYER_COUNT && <EmptyCell />}
+            {!isMaxPlayersSelected && <EmptyCell />}
           </TableRow>
 
           {/* Stats rows */}
@@ -160,17 +175,25 @@ export const ComparisonTable = ({
                 data-testid={`stat-row-${stat.name}`}
                 key={key}
               >
-                <FirstCell testId={`stat-label-cell-${stat.name}`}>
-                  <Typography className='text-ellipsis'>
-                    {stat.label}
-                  </Typography>
-                </FirstCell>
+                <TableCell
+                  component='td'
+                  data-testid={`stat-label-cell-${stat.name}`}
+                  sx={firstCellStyle}
+                >
+                  <Typography className='text-ellipsis'>{stat.label}</Typography>
+                </TableCell>
                 {selectedPlayers.map((player, key) => (
-                  <StandardCell key={key} testId={`stat-value-cell-${stat.name}-${player.id}`}>
+                  <TableCell
+                    className='first-cell'
+                    component='td'
+                    data-testid={`stat-value-cell-${stat.name}-${player.id}`}
+                    key={key}
+                    sx={standardCellStyle}
+                  >
                     <Typography>{player[stat.name]}</Typography>
-                  </StandardCell>
+                  </TableCell>
                 ))}
-                {selectedPlayers.length < MAX_PLAYER_COUNT && <EmptyCell />}
+                {!isMaxPlayersSelected && <EmptyCell />}
               </TableRow>
             );
           })}

--- a/src/components/comparison/player_image_cell.test.tsx
+++ b/src/components/comparison/player_image_cell.test.tsx
@@ -12,51 +12,13 @@ import { PlayerImageCell } from ".";
 describe("Player image cell tests", () => {
   const mockOnButtonClick = jest.fn();
 
-  const createComponent = (player?: Player): JSX.Element => {
+  const createComponent = (player: Player): JSX.Element => {
     return (
       <MockProviders>
         <PlayerImageCell onButtonClick={mockOnButtonClick} player={player} />
       </MockProviders>
     );
   };
-
-  describe("if no player prop is present", () => {
-    it("has expected style properties", () => {
-      render(createComponent());
-
-      const container = screen.getByTestId("player-image-container-placeholder");
-      const placeHolderImageUrl = getPlayerImageUrl();
-
-      expect(container).toHaveStyle(`background-image: url(${placeHolderImageUrl})`);
-      expect(container).toHaveStyle(`cursor: pointer`);
-      expect(container).toHaveStyle(`borderRadius: 50%`);
-    });
-
-    it("has onClick attribute if no player prop was passed", () => {
-      render(createComponent());
-
-      const container = screen.getByTestId("player-image-container-placeholder");
-      fireEvent.click(container);
-
-      expect(mockOnButtonClick).toHaveBeenCalledTimes(1);
-    });
-
-    it("add icon present", () => {
-      render(createComponent());
-
-      const container = within(screen.getByTestId("player-image-container-placeholder"));
-
-      expect(container.getByTestId("add-icon")).toBeInTheDocument();
-    });
-
-    it("remove icon not present", () => {
-      render(createComponent());
-
-      const container = within(screen.getByTestId("player-image-container-placeholder"));
-
-      expect(container.queryByTestId("remove-icon")).toBeNull();
-    });
-  });
 
   describe("if a player prop is present", () => {
     const mockPlayer = mockPlayers[0];

--- a/src/components/comparison/player_image_cell.tsx
+++ b/src/components/comparison/player_image_cell.tsx
@@ -1,56 +1,46 @@
 import React from "react";
-import { AddCircle, RemoveCircle } from "@mui/icons-material";
+import { RemoveCircle } from "@mui/icons-material";
 import { Box, IconButton } from "@mui/material";
 import { getPlayerImageUrl } from "helpers";
 import { Player } from "types";
 
 interface PlayerImageCellProps {
-  player?: Player;
+  player: Player;
   onButtonClick: () => void;
 }
 
 export const PlayerImageCell = ({ player, onButtonClick }: PlayerImageCellProps): JSX.Element => {
   const iconStyle = {
     position: "absolute",
-    ...player
-      ? {
-        cursor: "pointer",
-        right: 10,
-        top: 10
-      }
-      : {
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        zIndex: "modal"
-      }
+    cursor: "pointer",
+    right: 10,
+    top: 10
   };
 
+  const RemoveButton = (): JSX.Element => (
+    <IconButton
+      color='warning'
+      data-testid='action-button'
+      onClick={onButtonClick}
+      sx={iconStyle}
+    >
+      <RemoveCircle data-testid='remove-icon' />
+    </IconButton>
+  );
+
   return (
-    <Box>
-      <IconButton
-        color={player ? "warning" : "success"}
-        data-testid='action-button'
-        onClick={onButtonClick}
-        sx={iconStyle}
-      >
-        {player
-          ? <RemoveCircle data-testid='remove-icon' />
-          : <AddCircle data-testid='add-icon' />}
-      </IconButton>
+    <Box height='inherit'>
+      <RemoveButton />
       <Box
         className='flex-center'
-        data-testid={`player-image-container-${player?.id || "placeholder"}`}
-        height='15vh'
-        margin='auto'
+        data-testid={`player-image-container-${player.id}`}
+        height='100%'
         onClick={onButtonClick}
       >
         <img
-          alt={player ? `${player!.web_name} image` : "add player button"}
+          alt={`${player!.web_name} portrait`}
           height='100%'
           src={getPlayerImageUrl(player)}
-          width='auto'
         />
       </Box>
     </Box>


### PR DESCRIPTION
Fixes to the comparison table:
- Player images were overflowing in table cells
- Add player button refactored
- Fixed per page option on table in modal